### PR TITLE
6.5.1-NoAuth

### DIFF
--- a/Apprenda-MongoDB.Test/App.config
+++ b/Apprenda-MongoDB.Test/App.config
@@ -4,8 +4,8 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
   <appSettings>
-    <add key="username" value="dutra" />
-    <add key="password" value="dutra" />
+    <add key="username" value="apprendaadmin" />
+    <add key="password" value="password" />
     <add key="database" value="database"/>
   </appSettings>
 </configuration>

--- a/Apprenda-MongoDB.Test/Apprenda-MongoDB.Test.csproj
+++ b/Apprenda-MongoDB.Test/Apprenda-MongoDB.Test.csproj
@@ -54,7 +54,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -62,6 +64,9 @@
       <Project>{7e2af90c-aa84-4b06-9c94-4cd705222e4b}</Project>
       <Name>Apprenda-MongoDB</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Apprenda-MongoDB.Test/MongoTest.cs
+++ b/Apprenda-MongoDB.Test/MongoTest.cs
@@ -70,7 +70,7 @@
             var port = new AddonProperty
                             {
                                 Key = "port",
-                                Value = "32772"
+                                Value = "32770"
                             };
             var manifest = new AddonManifest
             {
@@ -90,7 +90,7 @@
                     Items = plist.ToArray()
                 },
                 Properties = new List<AddonProperty>(),                                 
-                ProvisioningLocation = "docker",
+                ProvisioningLocation = "54.167.117.101",
                 ProvisioningPassword = "admin",
                 ProvisioningPasswordHasValue = false,
                 ProvisioningUsername = "admin",
@@ -129,26 +129,21 @@
         }
 
         [Test]
-        public void ProvisionTest()
+        public void ProvisioningTest()
         {
             this.ProvisionRequest = new AddonProvisionRequest { Manifest = SetupPropertiesAndParameters(), DeveloperParameters = SetUpParameters()};
             var output = new MongoDbAddOn().Provision(this.ProvisionRequest);
             Assert.That(output, Is.TypeOf<ProvisionAddOnResult>());
             Assert.That(output.IsSuccess, Is.EqualTo(true));
             Assert.That(output.ConnectionData.Length, Is.GreaterThan(0));
-        }
-
-        [Test]
-        public void DeProvisionTest()
-        {
             this.DeprovisionRequest = new AddonDeprovisionRequest()
                                           {
                                               Manifest = SetupPropertiesAndParameters(),
                                               DeveloperParameters = SetUpParameters()
                                           };
-            var output = new MongoDbAddOn().Deprovision(this.DeprovisionRequest);
-            Assert.That(output, Is.TypeOf<OperationResult>());
-            Assert.That(output.IsSuccess, Is.EqualTo(true));
+            var de_output = new MongoDbAddOn().Deprovision(this.DeprovisionRequest);
+            Assert.That(de_output, Is.TypeOf<OperationResult>());
+            Assert.That(de_output.IsSuccess, Is.EqualTo(true));
         }
 
         [Test]

--- a/Apprenda.AddOns.MongoDB/MongoDbAddOn.cs
+++ b/Apprenda.AddOns.MongoDB/MongoDbAddOn.cs
@@ -63,10 +63,11 @@ namespace Apprenda.AddOns.MongoDB
                 // creates a new database. note - the database will not be created until something is written to it
                 var newCollection = database.GetCollection<ProvisioningData>("__provisioningData");
                 newCollection.InsertOne(new ProvisioningData());
-                
+
                 // Set the connection string that the app will use.
                 // This connection string includes the username and password given for this instance.
-                result.ConnectionData = string.Format("mongodb://{0}:{1}@{2}:{3}/{4}", _request.Manifest.ProvisioningUsername, _request.Manifest.ProvisioningPassword, _request.Manifest.ProvisioningLocation, port, databaseName);
+                //result.ConnectionData = string.Format("mongodb://{0}:{1}@{2}:{3}/{4}", _request.Manifest.ProvisioningUsername, _request.Manifest.ProvisioningPassword, _request.Manifest.ProvisioningLocation, port, databaseName);
+                result.ConnectionData = string.Format("mongodb://{0}:{1}/{2}", _request.Manifest.ProvisioningLocation, port, databaseName);
                 result.IsSuccess = true;
             }
             catch (MongoException mongoException)


### PR DESCRIPTION
Due to some issues with sasl and SHA-1 authentcation mechanisms, we've cut a release of the MongoDB addon that enables developers to spin up a MongoDB instance and create databases against it. 

This version does not use authentication, and therefore should not be used in a production scenario.